### PR TITLE
add ``__init__`` imports

### DIFF
--- a/Mmani/embedding/__init__.py
+++ b/Mmani/embedding/__init__.py
@@ -1,13 +1,7 @@
 """
 The :mod:`sklearn.Mmani` module implements data embedding techniques.
 """
-
-# from .locally_linear import locally_linear_embedding, LocallyLinearEmbedding
-# from .spectral_embedding_ import SpectralEmbedding, spectral_embedding
-# from .geometry import graph_laplacian, distance_matrix, DistanceMatrix, affinity_matrix
-# from .rmetric import *
-#from .isomap import Isomap
-#from .mds import MDS
-
-#__all__ = ['locally_linear_embedding', 'LocallyLinearEmbedding', 'Isomap',
-# __all__ = ['locally_linear_embedding', 'LocallyLinearEmbedding', 'spectral_embedding', 'SpectralEmbedding', 'graph_laplacian', 'riemann_metric', 'RiemannMetric', 'distance_matrix','DistanceMatrix','affinity_matrix', 'embed_with_rmetric']
+from .locally_linear import LocallyLinearEmbedding
+from .isomap import Isomap
+from .ltsa import LTSA
+from .spectral_embedding import SpectralEmbedding

--- a/Mmani/geometry/__init__.py
+++ b/Mmani/geometry/__init__.py
@@ -1,0 +1,2 @@
+from .rmetric import RiemannMetric
+from .geometry import Geometry


### PR DESCRIPTION
Some tiny things: I added a few of the more common API features to the higher-level namespace to make imports more intuitive.

There may be other similar things we could do as well.

Also, from an organizational standpoint, we may think about putting utilities (such as ``barycenter_graph``, ``center_matrix``, etc) into a separate utility file.