### PR TITLE
packaging: use numpy distutils and streamline setup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 junk*
 *.cxx
+*.c
 cythonize.dat
 
 MANIFEST

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *~
 *.pyc
 junk*
+*.cxx
+cythonize.dat
 
 MANIFEST
 

--- a/Mmani/__check_build/__init__.py
+++ b/Mmani/__check_build/__init__.py
@@ -1,0 +1,54 @@
+# Author: Jake VanderPlas
+# Adapted from scikit-learn's similar utility
+
+""" Module to give helpful messages to the user that did not
+compile Mmani properly (adapted from scikit-learn's check_build utility)
+"""
+import os
+
+INPLACE_MSG = """
+It appears that you are importing a local Mmani source tree.
+Please either use an inplace install or try from another location."""
+
+STANDARD_MSG = """
+If you have used an installer, please check that it is suited for your
+Python version, your operating system and your platform."""
+
+ERROR_TEMPLATE = """{error}
+___________________________________________________________________________
+Contents of {local_dir}:
+{contents}
+___________________________________________________________________________
+It seems that Mmani has not been built correctly.
+
+If you have installed Mmani from source, please do not forget
+to build the package before using it: run `python setup.py install`
+in the source directory.
+{msg}"""
+
+
+def raise_build_error(e):
+    # Raise a comprehensible error and list the contents of the
+    # directory to help debugging on the mailing list.
+    local_dir = os.path.split(__file__)[0]
+    msg = STANDARD_MSG
+    if local_dir == "Mmani/__check_build":
+        # Picking up the local install: this will work only if the
+        # install is an 'inplace build'
+        msg = INPLACE_MSG
+    dir_content = list()
+    for i, filename in enumerate(os.listdir(local_dir)):
+        if ((i + 1) % 3):
+            dir_content.append(filename.ljust(26))
+        else:
+            dir_content.append(filename + '\n')
+    contents = ''.join(dir_content).strip()
+    raise ImportError(ERROR_TEMPLATE.format(error=e,
+                                            local_dir=local_dir,
+                                            contents=contents,
+                                            msg=msg))
+
+try:
+    from ._check_build import check_build
+except ImportError as e:
+    raise_build_error(e)

--- a/Mmani/__check_build/_check_build.pyx
+++ b/Mmani/__check_build/_check_build.pyx
@@ -1,0 +1,2 @@
+def check_build():
+    return

--- a/Mmani/__check_build/setup.py
+++ b/Mmani/__check_build/setup.py
@@ -1,0 +1,15 @@
+import numpy
+
+
+def configuration(parent_package='', top_path=None):
+    from numpy.distutils.misc_util import Configuration
+    config = Configuration('__check_build', parent_package, top_path)
+    config.add_extension('_check_build',
+                         sources=['_check_build.c'],
+                         include_dirs=[numpy.get_include()])
+
+    return config
+
+if __name__ == '__main__':
+    from numpy.distutils.core import setup
+    setup(**configuration(top_path='').todict())

--- a/Mmani/__init__.py
+++ b/Mmani/__init__.py
@@ -1,3 +1,5 @@
 """Mmani: Scalable Manifold Learning"""
 
 __version__ = "0.1.dev0"
+
+from . import __check_build

--- a/Mmani/geometry/cyflann/index.pyx
+++ b/Mmani/geometry/cyflann/index.pyx
@@ -1,3 +1,5 @@
+# distutils: language=c++
+
 # Authors: Zhongyue Zhang <zhangz6@cs.washington.edu>
 # License: BSD 3 clause
 
@@ -12,13 +14,13 @@ cdef class Index:
     Wrapper for flann c++ index class
     """
     cdef CyflannIndex* _thisptr      # hold a C++ instance which we're wrapping
-    
-    def __cinit__(self, np.ndarray[double, ndim=2] dataset, 
+
+    def __cinit__(self, np.ndarray[double, ndim=2] dataset,
             target_precision=None, saved_index=None, index_type=None,
-            num_trees=4, branching=32, iterations=11, cb_index=0.2, 
+            num_trees=4, branching=32, iterations=11, cb_index=0.2,
             build_weight=0.01, memory_weight=0, sample_fraction=0.1):
         """
-        Constucts a index class. The default index is kmeans index. If target 
+        Constucts a index class. The default index is kmeans index. If target
         precision is specified, the index will be autotuned. If saved index is
         specified, the index will be loaded from the saved file. index_type can
         be either "kdtrees", "kmeans" or "composite".
@@ -28,7 +30,7 @@ cdef class Index:
         """
         if target_precision is not None:
             self._thisptr = new CyflannIndex(dataset.flatten(),
-                    dataset.shape[1], target_precision, build_weight, 
+                    dataset.shape[1], target_precision, build_weight,
                     memory_weight, sample_fraction)
         elif saved_index is not None:
             # setting the target precision is purely a way to get arround
@@ -37,21 +39,21 @@ cdef class Index:
                     dataset.shape[1], saved_index)
         elif index_type is not None:
             self._thisptr = new CyflannIndex(dataset.flatten(),
-                    dataset.shape[1], index_type, num_trees, branching, 
+                    dataset.shape[1], index_type, num_trees, branching,
                     iterations, cb_index)
         else:
             self._thisptr = new CyflannIndex(dataset.flatten(),
-                    dataset.shape[1])            
-    
+                    dataset.shape[1])
+
     def __dealloc__(self):
         del self._thisptr
-    
+
     def buildIndex(self):
         """
         Builds a index of the data for future queries.
         """
         self._thisptr.buildIndex()
-    
+
     def knn_neighbors_graph(self, np.ndarray[double, ndim=2] X, int knn):
         if knn < 1:
             raise ValueError('neighbors_radius must be >=0.')
@@ -67,7 +69,7 @@ cdef class Index:
         indpts = list(np.cumsum(lengths))
         indpts.insert(0,0)
         indpts = np.array(indpts)
-        # aparrently cython does not support iterating over vector withh 
+        # aparrently cython does not support iterating over vector withh
         # size = 1
         cdef np.ndarray[dtype_t, ndim=1] data = np.zeros(res, dtype=np.float32)
         cdef np.ndarray[dtypei_t, ndim=1] indices_list = np.zeros(
@@ -75,37 +77,37 @@ cdef class Index:
         self.fillDataAndIndices(data, indices_list, dists, indices)
         # self.size() is slower than self._thisptr.size(). def methods are
         # are usually quite a bit slower than cdef methods.
-        graph = sparse.csr_matrix((data, indices_list, indpts), shape = (nsam, 
+        graph = sparse.csr_matrix((data, indices_list, indpts), shape = (nsam,
                                   self._thisptr.size()))
         graph.data = np.sqrt(graph.data) # FLANN returns squared distance
         return graph
-    
+
     def radius_neighbors_graph(self, np.ndarray[double, ndim=2] X,
             float radius):
         """
         Constructs a sparse distance matrix called graph in csr
-        format. 
+        format.
         Parameters
         ----------
         X: data matrix, array_like, shape = (n_samples, n_dimensions )
         radius: neighborhood radius, scalar
             the neighbors lying approximately within radius of a node will
-            be returned. Or, in other words, all distances will be less or 
-            equal to radius. There will be entries in the matrix for zero 
+            be returned. Or, in other words, all distances will be less or
+            equal to radius. There will be entries in the matrix for zero
             distances.
-            
+
             Attention when converting to dense: The rest of the distances
             should not be considered 0, but "large".
-        
+
         Returns
         -------
         graph: the distance matrix, array_like, shape = (# of data points in
                dataset, # of data points in queries) sparse csr format
-        
+
         Notes
         -----
-        With approximate neiborhood search, the matrix is not necessarily 
-        symmetric. 
+        With approximate neiborhood search, the matrix is not necessarily
+        symmetric.
         """
         if radius < 0.:
             raise ValueError('neighbors_radius must be >=0.')
@@ -122,7 +124,7 @@ cdef class Index:
         indpts = list(np.cumsum(lengths))
         indpts.insert(0,0)
         indpts = np.array(indpts)
-        # aparrently cython does not support iterating over vector withh 
+        # aparrently cython does not support iterating over vector withh
         # size = 1
         cdef np.ndarray[dtype_t, ndim=1] data = np.zeros(res, dtype=np.float32)
         cdef np.ndarray[dtypei_t, ndim=1] indices_list = np.zeros(
@@ -130,32 +132,32 @@ cdef class Index:
         self.fillDataAndIndices(data, indices_list, dists, indices)
         # self.size() is slower than self._thisptr.size(). def methods are
         # are usually quite a bit slower than cdef methods.
-        graph = sparse.csr_matrix((data, indices_list, indpts), shape = (nsam, 
+        graph = sparse.csr_matrix((data, indices_list, indpts), shape = (nsam,
                                   self._thisptr.size()))
         graph.data = np.sqrt(graph.data) # FLANN returns squared distance
         return graph
-    
+
     def save(self, string filename):
         """
         Saves the index to a file.
         """
         self._thisptr.save(filename)
-    
+
     def veclen(self):
         """
         Length of a single data point
         """
         return self._thisptr.veclen()
-    
+
     def size(self):
         """
         Returns the number of data points in the current dataset.
         """
         return self._thisptr.size()
-        
-    cdef void fillDataAndIndices(self, np.ndarray[dtype_t, ndim=1] data, 
+
+    cdef void fillDataAndIndices(self, np.ndarray[dtype_t, ndim=1] data,
                             np.ndarray[dtypei_t, ndim=1] indices_list,
-                            vector[vector[dtype_t]] dists, 
+                            vector[vector[dtype_t]] dists,
                             vector[vector[dtypei_t]] indices):
         cdef int i, j, k
         k = 0
@@ -164,4 +166,3 @@ cdef class Index:
                 data[k] = dists[i][j]
                 indices_list[k] = indices[i][j]
                 k += 1
-    

--- a/Mmani/geometry/cyflann/setup.py
+++ b/Mmani/geometry/cyflann/setup.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import platform
 
 
 flann_root = os.environ.get('FLANN_ROOT', sys.exec_prefix)
@@ -14,9 +15,14 @@ def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
 
     config = Configuration('geometry/cyflann', parent_package, top_path)
-    libraries = ['flann_cpp']
+    libraries = ['flann', 'flann_cpp']
     if os.name == 'posix':
         libraries.append('m')
+
+    # from http://stackoverflow.com/questions/19123623/python-runtime-library-dirs-doesnt-work-on-mac
+    extra_link_args = []
+    if platform.system() == 'Darwin':
+        extra_link_args.append('-Wl,-rpath,'+flann_lib)
 
     config.add_extension("index",
            sources=["index.cxx", "cyflann_index.cc"],
@@ -24,6 +30,7 @@ def configuration(parent_package='', top_path=None):
            libraries = libraries,
            library_dirs = [flann_lib],
            runtime_library_dirs= [flann_lib],
+           extra_link_args=extra_link_args,
            extra_compile_args=["-O3"])
 
     return config

--- a/Mmani/geometry/cyflann/setup.py
+++ b/Mmani/geometry/cyflann/setup.py
@@ -1,20 +1,29 @@
-# Authors: Zhongyue Zhang <zhangz6@cs.washington.edu>
-# License: BSD 3 clause
-
-from distutils.core import setup
-from distutils.extension import Extension
-from Cython.Build import cythonize
 import os
+import sys
 
-# use "export FLANN_ROOT=<FLANN_ROOT>"to set enviromental variable
-# to build: python setup.py build_ext --inplace 
 
-flann_path = os.environ['FLANN_ROOT']   
+flann_root = os.environ.get('FLANN_ROOT', sys.exec_prefix)
+print("Compiling FLANN with FLANN_ROOT={0}".format(flann_root))
 
-setup(ext_modules = cythonize(
-    Extension(
-           "index",
-           sources=["index.pyx","cyflann_index.cc"],
-           language="c++",
-           extra_compile_args=["-O3", "-I" + flann_path + "/src/cpp/"],
-    )))
+flann_include = os.path.join(flann_root, 'include')
+flann_lib = os.path.join(flann_root, 'lib')
+
+
+def configuration(parent_package='', top_path=None):
+    import numpy
+    from numpy.distutils.misc_util import Configuration
+
+    config = Configuration('geometry/cyflann', parent_package, top_path)
+    libraries = ['flann', 'flann_cpp']
+    if os.name == 'posix':
+        libraries.append('m')
+
+    config.add_extension("index",
+           sources=["index.cpp", "cyflann_index.cc"],
+           include_dirs=[numpy.get_include(), flann_include],
+           libraries = libraries,
+           library_dirs = [flann_lib],
+           runtime_library_dirs= [flann_lib],
+           extra_compile_args=["-O3"])
+
+    return config

--- a/Mmani/geometry/cyflann/setup.py
+++ b/Mmani/geometry/cyflann/setup.py
@@ -14,12 +14,12 @@ def configuration(parent_package='', top_path=None):
     from numpy.distutils.misc_util import Configuration
 
     config = Configuration('geometry/cyflann', parent_package, top_path)
-    libraries = ['flann', 'flann_cpp']
+    libraries = ['flann_cpp']
     if os.name == 'posix':
         libraries.append('m')
 
     config.add_extension("index",
-           sources=["index.cpp", "cyflann_index.cc"],
+           sources=["index.cxx", "cyflann_index.cc"],
            include_dirs=[numpy.get_include(), flann_include],
            libraries = libraries,
            library_dirs = [flann_lib],

--- a/Mmani/setup.py
+++ b/Mmani/setup.py
@@ -11,6 +11,7 @@ def configuration(parent_package='', top_path=None):
 
     config = Configuration('Mmani', parent_package, top_path)
 
+    config.add_subpackage('__check_build')
     config.add_subpackage('embedding')
     config.add_subpackage('embedding/tests')
     config.add_subpackage('geometry')

--- a/Mmani/setup.py
+++ b/Mmani/setup.py
@@ -1,0 +1,26 @@
+import os
+
+def configuration(parent_package='', top_path=None):
+    from numpy.distutils.misc_util import Configuration
+    from numpy.distutils.system_info import get_info, BlasNotFoundError
+    import numpy
+
+    libraries = []
+    if os.name == 'posix':
+        libraries.append('m')
+
+    config = Configuration('Mmani', parent_package, top_path)
+
+    config.add_subpackage('embedding')
+    config.add_subpackage('embedding/tests')
+    config.add_subpackage('geometry')
+    config.add_subpackage('geometry/cyflann')
+    config.add_subpackage('geometry/tests')
+    config.add_subpackage('utils')
+    config.add_subpackage('utils/tests')
+
+    return config
+
+if __name__ == '__main__':
+    from numpy.distutils.core import setup
+    setup(**configuration(top_path='').todict())

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import io
 import os
 import re
 import sys
+import subprocess
 
 
 def read(path, encoding='utf-8'):
@@ -21,6 +22,18 @@ def version(path):
     if version_match:
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
+
+
+def generate_cython():
+    cwd = os.path.abspath(os.path.dirname(__file__))
+    print("Cythonizing sources")
+    p = subprocess.call([sys.executable,
+                         os.path.join(cwd, 'tools', 'cythonize.py'),
+                         'Mmani'],
+                        cwd=cwd)
+    if p != 0:
+        raise RuntimeError("Running cythonize failed!")
+
 
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
@@ -68,6 +81,11 @@ def setup_package():
     old_path = os.getcwd()
     os.chdir(src_path)
     sys.path.insert(0, src_path)
+
+    cwd = os.path.abspath(os.path.dirname(__file__))
+    if not os.path.exists(os.path.join(cwd, 'PKG-INFO')):
+        # Generate Cython sources, unless building from source release
+        generate_cython()
 
     try:
         setup(name='Mmani',

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 import io
 import os
 import re
-
-from distutils.core import setup
+import sys
 
 
 def read(path, encoding='utf-8'):
@@ -23,6 +22,17 @@ def version(path):
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
 
+def configuration(parent_package='',top_path=None):
+    from numpy.distutils.misc_util import Configuration
+    config = Configuration(None, parent_package, top_path)
+    config.set_options(ignore_setup_xxx_py=True,
+                       assume_default_configuration=True,
+                       delegate_options_to_subpackages=True,
+                       quiet=True)
+
+    config.add_subpackage('Mmani')
+
+    return config
 
 DESCRIPTION = "Mmani: Scalable Manifold Learning"
 LONG_DESCRIPTION = """
@@ -43,27 +53,45 @@ LICENSE = 'BSD 3'
 
 VERSION = version('Mmani/__init__.py')
 
-setup(name=NAME,
-      version=VERSION,
-      description=DESCRIPTION,
-      long_description=LONG_DESCRIPTION,
-      author=AUTHOR,
-      url=URL,
-      download_url=DOWNLOAD_URL,
-      license=LICENSE,
-      packages=['Mmani',
-                'Mmani.embedding',
-                'Mmani.embedding.tests',
-                'Mmani.geometry',
-                'Mmani.geometry.tests',
-                'Mmani.utils',
-                'Mmani.utils.tests',
-            ],
-      classifiers=[
-        'Development Status :: 4 - Beta',
-        'Environment :: Console',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 2.7'],
-     )
+
+def setup_package():
+    from numpy.distutils.core import setup
+
+    old_path = os.getcwd()
+    local_path = os.path.dirname(os.path.abspath(sys.argv[0]))
+    src_path = local_path
+
+    os.chdir(local_path)
+    sys.path.insert(0, local_path)
+
+    # Run build
+    old_path = os.getcwd()
+    os.chdir(src_path)
+    sys.path.insert(0, src_path)
+
+    try:
+        setup(name='Mmani',
+              author=AUTHOR,
+              url=URL,
+              download_url=DOWNLOAD_URL,
+              description=DESCRIPTION,
+              long_description = LONG_DESCRIPTION,
+              version=VERSION,
+              license=LICENSE,
+              configuration=configuration,
+              classifiers=[
+                'Development Status :: 4 - Beta',
+                'Environment :: Console',
+                'Intended Audience :: Science/Research',
+                'License :: OSI Approved :: BSD License',
+                'Natural Language :: English',
+                'Programming Language :: Python :: 2.7'],)
+    finally:
+        del sys.path[0]
+        os.chdir(old_path)
+
+    return
+
+
+if __name__ == '__main__':
+    setup_package()

--- a/tools/cythonize.py
+++ b/tools/cythonize.py
@@ -1,0 +1,189 @@
+# Copied from scipy
+
+""" cythonize
+Cythonize pyx files into C files as needed.
+Usage: cythonize [root_dir]
+Default [root_dir] is 'Mmani'.
+Checks pyx files to see if they have been changed relative to their
+corresponding C files.  If they have, then runs cython on these files to
+recreate the C files.
+The script thinks that the pyx files have changed relative to the C files
+by comparing hashes stored in a database file.
+Simple script to invoke Cython (and Tempita) on all .pyx (.pyx.in)
+files; while waiting for a proper build system. Uses file hashes to
+figure out if rebuild is needed.
+For now, this script should be run by developers when changing Cython files
+only, and the resulting C files checked in, so that end-users (and Python-only
+developers) do not get the Cython/Tempita dependencies.
+Originally written by Dag Sverre Seljebotn, and copied here from:
+https://raw.github.com/dagss/private-scipy-refactor/cythonize/cythonize.py
+Note: this script does not check any of the dependent C libraries; it only
+operates on the Cython .pyx files.
+"""
+
+from __future__ import division, print_function, absolute_import
+
+import os
+import re
+import sys
+import hashlib
+import subprocess
+
+HASH_FILE = 'cythonize.dat'
+DEFAULT_ROOT = 'Mmani'
+
+# WindowsError is not defined on unix systems
+try:
+    WindowsError
+except NameError:
+    WindowsError = None
+
+#
+# Rules
+#
+def process_pyx(fromfile, tofile):
+    try:
+        from Cython.Compiler.Version import version as cython_version
+        from distutils.version import LooseVersion
+        if LooseVersion(cython_version) < LooseVersion('0.22'):
+            raise Exception('Building Mmani requires Cython >= 0.22')
+
+    except ImportError:
+        pass
+
+    flags = ['--fast-fail']
+    if tofile.endswith('.cxx'):
+        flags += ['--cplus']
+
+    try:
+        try:
+            r = subprocess.call(['cython'] + flags + ["-o", tofile, fromfile])
+            if r != 0:
+                raise Exception('Cython failed')
+        except OSError:
+            # There are ways of installing Cython that don't result in a cython
+            # executable on the path, see gh-2397.
+            r = subprocess.call([sys.executable, '-c',
+                                 'import sys; from Cython.Compiler.Main import '
+                                 'setuptools_main as main; sys.exit(main())'] + flags +
+                                 ["-o", tofile, fromfile])
+            if r != 0:
+                raise Exception("Cython either isn't installed or it failed.")
+    except OSError:
+        raise OSError('Cython needs to be installed')
+
+def process_tempita_pyx(fromfile, tofile):
+    try:
+        try:
+            from Cython import Tempita as tempita
+        except ImportError:
+            import tempita
+    except ImportError:
+        raise Exception('Building Mmani requires Tempita: '
+                        'pip install --user Tempita')
+    from_filename = tempita.Template.from_filename
+    template = from_filename(fromfile, encoding=sys.getdefaultencoding())
+    pyxcontent = template.substitute()
+    assert fromfile.endswith('.pyx.in')
+    pyxfile = fromfile[:-len('.pyx.in')] + '.pyx'
+    with open(pyxfile, "w") as f:
+        f.write(pyxcontent)
+    process_pyx(pyxfile, tofile)
+
+rules = {
+    # fromext : function
+    '.pyx': process_pyx,
+    '.pyx.in': process_tempita_pyx
+    }
+#
+# Hash db
+#
+def load_hashes(filename):
+    # Return { filename : (sha1 of input, sha1 of output) }
+    if os.path.isfile(filename):
+        hashes = {}
+        with open(filename, 'r') as f:
+            for line in f:
+                filename, inhash, outhash = line.split()
+                hashes[filename] = (inhash, outhash)
+    else:
+        hashes = {}
+    return hashes
+
+def save_hashes(hash_db, filename):
+    with open(filename, 'w') as f:
+        for key, value in sorted(hash_db.items()):
+            f.write("%s %s %s\n" % (key, value[0], value[1]))
+
+def sha1_of_file(filename):
+    h = hashlib.sha1()
+    with open(filename, "rb") as f:
+        h.update(f.read())
+    return h.hexdigest()
+
+#
+# Main program
+#
+
+def normpath(path):
+    path = path.replace(os.sep, '/')
+    if path.startswith('./'):
+        path = path[2:]
+    return path
+
+def get_hash(frompath, topath):
+    from_hash = sha1_of_file(frompath)
+    to_hash = sha1_of_file(topath) if os.path.exists(topath) else None
+    return (from_hash, to_hash)
+
+def process(path, fromfile, tofile, processor_function, hash_db):
+    fullfrompath = os.path.join(path, fromfile)
+    fulltopath = os.path.join(path, tofile)
+    current_hash = get_hash(fullfrompath, fulltopath)
+    if current_hash == hash_db.get(normpath(fullfrompath), None):
+        print('%s has not changed' % fullfrompath)
+        return
+
+    orig_cwd = os.getcwd()
+    try:
+        os.chdir(path)
+        print('Processing %s' % fullfrompath)
+        processor_function(fromfile, tofile)
+    finally:
+        os.chdir(orig_cwd)
+    # changed target file, recompute hash
+    current_hash = get_hash(fullfrompath, fulltopath)
+    # store hash in db
+    hash_db[normpath(fullfrompath)] = current_hash
+
+
+def find_process_files(root_dir):
+    hash_db = load_hashes(HASH_FILE)
+    for cur_dir, dirs, files in os.walk(root_dir):
+        for filename in files:
+            in_file = os.path.join(cur_dir, filename + ".in")
+            if filename.endswith('.pyx') and os.path.isfile(in_file):
+                continue
+            for fromext, function in rules.items():
+                if filename.endswith(fromext):
+                    toext = ".c"
+                    with open(os.path.join(cur_dir, filename), 'rb') as f:
+                        data = f.read()
+                        m = re.search(br"^\s*#\s*distutils:\s*language\s*=\s*c\+\+\s*$", data, re.I|re.M)
+                        if m:
+                            toext = ".cxx"
+                    fromfile = filename
+                    tofile = filename[:-len(fromext)] + toext
+                    process(cur_dir, fromfile, tofile, function, hash_db)
+                    save_hashes(hash_db, HASH_FILE)
+
+def main():
+    try:
+        root_dir = sys.argv[1]
+    except IndexError:
+        root_dir = DEFAULT_ROOT
+    find_process_files(root_dir)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
In progress PR:

My goal here is to simplify the build step – rather than having to build cyflann separately, this builds it as a submodule extension. ~~I've still not been able to install the package on my Mac, despite having three working installations of FLANN (one from homebrew, one from conda, one from source). Installation is fine, but I'm getting dylib linking errors at runtime and have spent several hours trying to figure out how to fix them.~~

The build now works for me on OSX, using flann installed by anaconda. Linux should work as well: if so I'll update the documentation and merge this.